### PR TITLE
Now supporting a map object as a parameter for the neo4j string

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hugneo4j "0.0.8"
+(defproject hugneo4j "0.0.9"
   :description "HugNeo4j offers a similar experience to the excellent HugSql library but for neo4j. As a matter of fact this library copies some very important parts from HugSql"
   :url "https://github.com/rams-services/hugneo4j"
   :license {:name "Apache License, Version 2.0"

--- a/src/hugneo4j/core.clj
+++ b/src/hugneo4j/core.clj
@@ -3,7 +3,6 @@
             [hugneo4j.parameters :as parameters]
             [hugneo4j.cypher :as cypher]
             [clojure.java.io :as io]
-            [clojure.tools.logging :as log]
             [clojure.string :as string]
             [clojure.tools.reader.edn :as edn]))
 

--- a/src/hugneo4j/core.clj
+++ b/src/hugneo4j/core.clj
@@ -50,15 +50,20 @@
    and throw an exception if mismatch."
   [cypher-template param-data]
   (let [not-found (Object.)]
-    (doseq [k (map :name (filter map? cypher-template))]
-      (when-not
-       (not-any?
-        #(= not-found %)
-        (map #(get-in param-data % not-found)
-             (rest (reductions
-                    (fn [r x] (conj r x))
-                    []
-                    (parameters/deep-get-vec k)))))
+    (doseq [param (filter map? cypher-template)
+            :let [k (:name param)
+                  h? (:map-object param)]]
+      (when
+          (or
+           (some
+            #(= not-found %)
+            (map #(get-in param-data % not-found)
+                 (rest (reductions
+                        (fn [r x] (conj r x))
+                        []
+                        (parameters/deep-get-vec k)))))
+           (and h?
+                (empty? (get-in param-data (parameters/deep-get-vec k) not-found))))
         (throw (ex-info
                 (str "Parameter Mismatch: "
                      k " parameter data not found.") {}))))))


### PR DESCRIPTION
The format used is eg: 
```MATCH(n:TestNode) SET #n $m, n.`updated?` = true RETURN n``` with the props ```{:m {:name "test", :type "query"}}```  
==>  ```MATCH(n:TestNode) SET `n`.`name` = $`m`.`name`, `n`.`type` = $`m`.`type`, n.`updated?` = true RETURN n```